### PR TITLE
Replace 'string' type with 'text', and replace 'not_analyzed' with keyword fields

### DIFF
--- a/haystack_elasticsearch/elasticsearch.py
+++ b/haystack_elasticsearch/elasticsearch.py
@@ -705,8 +705,8 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
     def build_schema(self, fields):
         content_field_name = ''
         mapping = {
-            DJANGO_CT: {'type': 'string', 'index': 'not_analyzed', 'include_in_all': False},
-            DJANGO_ID: {'type': 'string', 'index': 'not_analyzed', 'include_in_all': False},
+            DJANGO_CT: {'type': 'keyword'},
+            DJANGO_ID: {'type': 'keyword'},
         }
 
         for field_name, field_class in fields.items():
@@ -718,9 +718,9 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
                 content_field_name = field_class.index_fieldname
 
             # Do this last to override `text` fields.
-            if field_mapping['type'] == 'string':
+            if field_mapping['type'] == 'text':
                 if field_class.indexed is False or hasattr(field_class, 'facet_for'):
-                    field_mapping['index'] = 'not_analyzed'
+                    field_mapping['type'] = 'keyword'
                     del field_mapping['analyzer']
 
             mapping[field_class.index_fieldname] = field_mapping
@@ -792,10 +792,10 @@ class ElasticsearchSearchBackend(BaseSearchBackend):
 # DRL_FIXME: Perhaps move to something where, if none of these
 #            match, call a custom method on the form that returns, per-backend,
 #            the right type of storage?
-DEFAULT_FIELD_MAPPING = {'type': 'string', 'analyzer': 'snowball'}
+DEFAULT_FIELD_MAPPING = {'type': 'text', 'analyzer': 'snowball'}
 FIELD_MAPPINGS = {
-    'edge_ngram': {'type': 'string', 'analyzer': 'edgengram_analyzer'},
-    'ngram':      {'type': 'string', 'analyzer': 'ngram_analyzer'},
+    'edge_ngram': {'type': 'text', 'analyzer': 'edgengram_analyzer'},
+    'ngram':      {'type': 'text', 'analyzer': 'ngram_analyzer'},
     'date':       {'type': 'date'},
     'datetime':   {'type': 'date'},
 


### PR DESCRIPTION
This patch fixes some behaviour that was depracated in ES 5 (see the relevant sections at https://www.elastic.co/guide/en/elasticsearch/reference/5.5/breaking_50_mapping_changes.html)

- The 'string' datatype was depracated in ES 5, so replace it with 'text'.
- The 'index' property now only accepts true/false, so replace index=not_analyzed
  fields with 'keyword' datatype